### PR TITLE
fixing host count for IPv4 and broadcast for IPv6

### DIFF
--- a/bin/network-divide
+++ b/bin/network-divide
@@ -14,7 +14,6 @@ import argparse
 
 from subnet import ip_network
 
-
 parser = argparse.ArgumentParser(
     description='Divide a network into the desired amount of subnets, maintaining an even'
                 ' distribution of size across all subnets. This means that there could be'
@@ -31,9 +30,10 @@ for subnet in net.divide(args.parts):
     print(f"CIDR:       {subnet}")
     print(f"Netmask:    {subnet.netmask}")
     print(f"Network:    {subnet.network_address}")
-    if subnet.num_addresses == 1:
-        print(f"Host Count: 1")
-    else:
-        print(f"Gateway:    {subnet.network_address+1}")
+
+    if subnet.version == 4 and subnet.num_addresses > 2:
         print(f"Broadcast:  {subnet.broadcast_address}")
-        print(f"Host Count: {subnet.num_addresses-1}")
+        print(f"Gateway:    {subnet.network_address + 1}")
+        print(f"Host Count: {subnet.num_addresses - 2}")  # exclude network and broadcast address
+    else:
+        print(f"Host Count: {subnet.num_addresses}")  # IPv4 RFC 3021 exception and IPv6 in general

--- a/bin/network-info
+++ b/bin/network-info
@@ -24,9 +24,10 @@ net = ip_network(args.network, strict=False)
 print(f"CIDR:       {net}")
 print(f"Netmask:    {net.netmask}")
 print(f"Network:    {net.network_address}")
-if net.num_addresses == 1:
-    print(f"Host Count: 1")
-else:
-    print(f"Gateway:    {net.network_address+1}")
+
+if net.version == 4 and net.num_addresses > 2:
     print(f"Broadcast:  {net.broadcast_address}")
-    print(f"Host Count: {net.num_addresses-1}")
+    print(f"Gateway:    {net.network_address + 1}")
+    print(f"Host Count: {net.num_addresses - 2}")  # exclude network and broadcast address
+else:
+    print(f"Host Count: {net.num_addresses}")  # IPv4 RFC 3021 exception and IPv6 in general


### PR DESCRIPTION
The host count is not correct I believe:

* `num_addresses - 2` (take off network address and broadcast address) &rarr; if more then 2 addresses and IPv4
* `num_addresses` &rarr; if 1 or 2 addresses (e.g. [/31 point-to-point links](https://community.cisco.com/t5/switching/when-and-why-we-use-31-subnet/td-p/1642780)) or IPv6

Further a subnet broadcast address is [available in IPv4](https://docs.netgate.com/pfsense/en/latest/network/ipv6/subnets.html) only.